### PR TITLE
fix: disable sourcemap generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "moduleResolution": "node",
         "target": "ESNext",
         "outDir": "dist",
-        "sourceMap": true,
+        "sourceMap": false,
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,


### PR DESCRIPTION
Sourcemap (*.js.map) breaks runtime process & giving SyntaxError code.Disable it so the runtime process can run properly